### PR TITLE
Pin older dependencies until OGB team repo is ready for pytorch 2.6

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
+pip install torch==2.5.1
 pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-2.2.1+cu121.html
 pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-2.2.1+cu121.html
-pip install torch-geometric
-pip install ogb
+pip install torch-geometric==2.5.3
+pip install ogb==1.3.6


### PR DESCRIPTION
For https://github.com/willy-b/tiny-GIN-for-ogbg-molhiv/issues/9 pin older dependencies until OGB team repo is ready for PyTorch 2.6.

After PyTorch 2.6,  Torch disapproves of the usage of torch.load at https://github.com/snap-stanford/ogb/blob/861511315ad4b4082d10662d081c3cae14cfc3ea/ogb/graphproppred/dataset_pyg.py#L68 , which is not weights only.

OGB team has an open issue for this on their repo, so will just hold onto the old versions until they make an update and then allow this repo to move to newer PyTorch. See issue for workarounds if you really want to use latest PyTorch and PyTorch Geometric with this repo, it is possible to override to allow this behavior in the global Torch configuration and there are various other workarounds.